### PR TITLE
api: use map for constructorParams and one endpoint

### DIFF
--- a/main.go
+++ b/main.go
@@ -13,82 +13,10 @@ import (
 	"github.com/gin-gonic/gin"
 )
 
-type AccessMaster struct {
+type Contract struct {
 	Data struct {
-		ContractName      string `json:"contractName"`
-		ConstructorParams struct {
-		} `json:"constructorParams"`
-	}
-	Network string `json:"network"`
-}
-type TradeHub struct {
-	Data struct {
-		ContractName      string `json:"contractName"`
-		ConstructorParams struct {
-			Param1 int    `json:"param1"`
-			Param2 string `json:"param2"`
-			Param3 string `json:"param3"`
-		} `json:"constructorParams"`
-	}
-	Network string `json:"network"`
-}
-type FusionSeries struct {
-	Data struct {
-		ContractName      string `json:"contractName"`
-		ConstructorParams struct {
-			Param1 string `json:"param1"`
-			Param2 string `json:"param2"`
-			Param3 string `json:"param3"`
-		} `json:"constructorParams"`
-	}
-	Network string `json:"network"`
-}
-type SignatureSeries struct {
-	Data struct {
-		ContractName      string `json:"contractName"`
-		ConstructorParams struct {
-			Param1 string `json:"param1"`
-			Param2 string `json:"param2"`
-			Param3 string `json:"param3"`
-			Param4 string `json:"param4"`
-		} `json:"constructorParams"`
-	}
-	Network string `json:"network"`
-}
-type InstaGen struct {
-	Data struct {
-		ContractName      string `json:"contractName"`
-		ConstructorParams struct {
-			Param1  string `json:"param1"`
-			Param2  string `json:"param2"`
-			Param3  string `json:"param3"`
-			Param4  string `json:"param4"`
-			Param5  string `json:"param5"`
-			Param6  string `json:"param6"`
-			Param7  int    `json:"param7"`
-			Param8  int    `json:"param8"`
-			Param9  int    `json:"param9"`
-			Param10 string `json:"param10"`
-		} `json:"constructorParams"`
-	}
-	Network string `json:"network"`
-}
-
-type EternumPass struct {
-	Data struct {
-		ContractName      string `json:"contractName"`
-		ConstructorParams struct {
-			Param1  string `json:"param1"`
-			Param2  string `json:"param2"`
-			Param3  string `json:"param3"`
-			Param4  string `json:"param4"`
-			Param5  string `json:"param5"`
-			Param6  string `json:"param6"`
-			Param7  string `json:"param7"`
-			Param8  bool   `json:"param8"`
-			Param9  string `json:"param9"`
-			Param10 string `json:"param10"`
-		} `json:"constructorParams"`
+		ContractName      string         `json:"contractName"`
+		ConstructorParams map[string]any `json:"constructorParams"`
 	}
 	Network string `json:"network"`
 }
@@ -99,19 +27,14 @@ func main() {
 	config.AllowAllOrigins = true
 
 	router.Use(cors.New(config))
-	router.POST("/AccessMaster", DeployAccessMaster)
-	router.POST("/TradeHub", DeployTradeHub)
-	router.POST("/FusionSeries", DeployFusionSeries)
-	router.POST("/SignatureSeries", DeploySignatureSeries)
-	router.POST("/InstaGen", DeployInstaGen)
-	router.POST("/EternumPass", DeployEternumPass)
 
+	router.POST("/Contract", DeployContract)
 	router.Use(cors.New(config))
 	router.Run(":8080")
 }
 
-func DeployTradeHub(c *gin.Context) {
-	var req TradeHub
+func DeployContract(c *gin.Context) {
+	var req Contract
 	if err := c.ShouldBindJSON(&req); err != nil {
 		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
 		return
@@ -129,105 +52,7 @@ func DeployTradeHub(c *gin.Context) {
 	}
 
 	c.JSON(http.StatusOK, response)
-}
-func DeployAccessMaster(c *gin.Context) {
-	var req AccessMaster
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	network := req.Network
-	jsonByte, err := json.Marshal(req.Data)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	response, err := genResponse(jsonByte, network)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
 
-	c.JSON(http.StatusOK, response)
-}
-func DeployFusionSeries(c *gin.Context) {
-	var req FusionSeries
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	network := req.Network
-	jsonByte, err := json.Marshal(req.Data)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	response, err := genResponse(jsonByte, network)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusOK, response)
-}
-func DeploySignatureSeries(c *gin.Context) {
-	var req SignatureSeries
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	network := req.Network
-	jsonByte, err := json.Marshal(req.Data)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	response, err := genResponse(jsonByte, network)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusOK, response)
-}
-func DeployInstaGen(c *gin.Context) {
-	var req InstaGen
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	network := req.Network
-	jsonByte, err := json.Marshal(req.Data)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	response, err := genResponse(jsonByte, network)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-
-	c.JSON(http.StatusOK, response)
-}
-func DeployEternumPass(c *gin.Context) {
-	var req EternumPass
-	if err := c.ShouldBindJSON(&req); err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	network := req.Network
-	jsonByte, err := json.Marshal(req.Data)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	response, err := genResponse(jsonByte, network)
-	if err != nil {
-		c.JSON(http.StatusInternalServerError, gin.H{"error": err.Error()})
-		return
-	}
-	c.JSON(http.StatusOK, response)
 }
 
 func genResponse(jsonByte []byte, network string) ([]byte, error) {


### PR DESCRIPTION
There was no need for seperate structs for different constructorParams as we don't specifically use each value inside it. Use general map for it. Remove different endpoints for each contract